### PR TITLE
(Non default) character set: hex_char

### DIFF
--- a/include/ctve.hpp
+++ b/include/ctve.hpp
@@ -26,7 +26,7 @@ static inline constexpr auto digit = impl::character_type{"\\d"};
 static inline constexpr auto non_digit = impl::character_type{"\\D"};
 static inline constexpr auto tab = impl::character_type{"\\t"};
 
-static inline constexpr auto hex_char = in(digit, range{ 'a', 'f' }, range{ 'A', 'F' });
+static inline constexpr auto xdigit = in(digit, range{ 'a', 'f' }, range{ 'A', 'F' });
 
 namespace posix
 {

--- a/include/ctve.hpp
+++ b/include/ctve.hpp
@@ -26,6 +26,8 @@ static inline constexpr auto digit = impl::character_type{"\\d"};
 static inline constexpr auto non_digit = impl::character_type{"\\D"};
 static inline constexpr auto tab = impl::character_type{"\\t"};
 
+static inline constexpr auto hex_char = in(digit, range{ 'a', 'f' }, range{ 'A', 'F' });
+
 namespace posix
 {
 static inline constexpr auto alnum = impl::character_type{"[:alnum:]"};


### PR DESCRIPTION
Add (non default) "hex_char" ([0-9a-zA-Z] as character set.
This change would help to build complex regex patterns containing hex characters more easily with ctve.